### PR TITLE
Proof of concept guzzle 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor/
 /composer.lock
+.idea

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,12 @@
         }
     ],
     "require": {
-        "php": ">=5.4.0",
-        "guzzlehttp/guzzle": ">=5.3 <7.0"
+        "php": "^7.2|^8.0",
+        "guzzlehttp/guzzle": "~7.0",
+        "guzzlehttp/uri-template": "0.2.0"
     },
 	"require-dev": {
-        "phpunit/phpunit": "4.8.*"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -1,12 +1,13 @@
 <?php
-namespace HapiClient\tests;
+namespace HapiClient\Tests;
 
 use HapiClient\Http;
 use HapiClient\Http\Auth;
 use HapiClient\Hal;
 use HapiClient\Exception;
+use PHPUnit\Framework\TestCase;
 
-class ClientTest extends \PHPUnit_Framework_TestCase
+class ClientTest extends TestCase
 {
     const APIURL = 'https://api.preprod.slimpay.com';
     const PROFILEURL = 'https://api.slimpay.net/alps/v1';

--- a/tests/ResourceTest.php
+++ b/tests/ResourceTest.php
@@ -2,8 +2,9 @@
 namespace HapiClient\tests;
 
 use HapiClient\Hal;
+use PHPUnit\Framework\TestCase;
 
-class ResourceTest extends \PHPUnit_Framework_TestCase
+class ResourceTest extends TestCase
 {
     const JSON_REPRESENTATION = <<<END
 {

--- a/tests/WrongCredentialsTest.php
+++ b/tests/WrongCredentialsTest.php
@@ -4,8 +4,9 @@ namespace HapiClient\tests;
 use HapiClient\Http;
 use HapiClient\Http\Auth;
 use HapiClient\Exception;
+use PHPUnit\Framework\TestCase;
 
-class WrongCredentialsTest extends \PHPUnit_Framework_TestCase
+class WrongCredentialsTest extends TestCase
 {
     const APIURL = 'https://api.preprod.slimpay.com';
     const PROFILEURL = 'https://api.slimpay.net/alps/v1';


### PR DESCRIPTION
See #14. There is a https://github.com/guzzle/uri-template "polyfill" package which would make upgrading to Guzzle 7 a lot easier. We have been waiting for a very long time after contacting support about this issue.

The package is currently not compatible in a Laravel 8 project.

- I set the min PHP version to 7.2 which is required by Guzzle 7
- I added the guzzle/uri-template package and replaced the import in HapiClient.php
- I updated PHPUnit to version 9 to check. I got 2 forbidden messages but this is something which can be checked / fixed by Slimpay.
